### PR TITLE
Add wallet management screens and routing

### DIFF
--- a/lib/core/routes/app_routes.dart
+++ b/lib/core/routes/app_routes.dart
@@ -16,12 +16,15 @@ import '../../data/models/transaction_model.dart';
 import '../../features/settings/screens/settings_screen.dart';
 import '../../features/settings/screens/categories_screen.dart';
 import '../../features/settings/screens/backup_screen.dart';
+import '../../features/settings/screens/wallet_settings_screen.dart';
+import '../../features/settings/screens/edit_wallet_screen.dart';
 import '../../features/settings/screens/notification_settings_screen.dart';
 import '../../features/notifications/screens/notification_inbox_screen.dart';
 import '../../features/security/screens/security_settings_screen.dart';
 import '../../features/security/screens/setup_pin_screen.dart';
 import '../../features/security/screens/change_pin_screen.dart';
 import '../../features/security/screens/unlock_screen.dart';
+import '../../data/models/wallet_model.dart';
 
 /// App route names
 class AppRoutes {
@@ -51,6 +54,7 @@ class AppRoutes {
   static const String walletDetail = '/wallets/detail';
   static const String createWallet = '/wallets/create';
   static const String editWallet = '/wallets/edit';
+  static const String walletSettings = '/settings/wallets';
 
   // Transactions
   static const String transactions = '/transactions';
@@ -246,6 +250,26 @@ class RouteGenerator {
       case AppRoutes.unlock:
         return MaterialPageRoute(
           builder: (_) => const UnlockScreen(),
+          settings: settings,
+        );
+
+      case AppRoutes.walletSettings:
+        return MaterialPageRoute(
+          builder: (_) => const WalletSettingsScreen(),
+          settings: settings,
+        );
+
+      case AppRoutes.editWallet:
+        final wallet = settings.arguments as Wallet?;
+        if (wallet == null) {
+          return MaterialPageRoute(
+            builder: (_) => const Scaffold(
+              body: Center(child: Text('Wallet not found')),
+            ),
+          );
+        }
+        return MaterialPageRoute(
+          builder: (_) => EditWalletScreen(wallet: wallet),
           settings: settings,
         );
 

--- a/lib/features/security/screens/unlock_screen.dart
+++ b/lib/features/security/screens/unlock_screen.dart
@@ -16,6 +16,7 @@ class _UnlockScreenState extends State<UnlockScreen> {
   int _attemptCount = 0;
   final int _maxAttempts = 5;
   bool _canUseBiometric = false;
+  bool _biometricTriggered = false;
 
   @override
   void initState() {
@@ -30,10 +31,13 @@ class _UnlockScreenState extends State<UnlockScreen> {
         _canUseBiometric = available;
       });
       
-      // Auto-trigger biometric on first load
-      if (available) {
+      // Auto-trigger biometric on first load only once
+      if (available && !_biometricTriggered) {
+        _biometricTriggered = true;
         Future.delayed(const Duration(milliseconds: 500), () {
-          _authenticateWithBiometric();
+          if (mounted) {
+            _authenticateWithBiometric();
+          }
         });
       }
     }

--- a/lib/features/settings/screens/edit_wallet_screen.dart
+++ b/lib/features/settings/screens/edit_wallet_screen.dart
@@ -1,0 +1,464 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../../../core/constants/app_colors.dart';
+import '../../../data/models/wallet_model.dart';
+import '../../../data/repositories/wallet_repository.dart';
+
+class EditWalletScreen extends StatefulWidget {
+  final Wallet wallet;
+
+  const EditWalletScreen({
+    super.key,
+    required this.wallet,
+  });
+
+  @override
+  State<EditWalletScreen> createState() => _EditWalletScreenState();
+}
+
+class _EditWalletScreenState extends State<EditWalletScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _providerController = TextEditingController();
+  final _accountNumberController = TextEditingController();
+  final _balanceController = TextEditingController();
+  final WalletRepository _walletRepository = WalletRepository();
+  
+  String _selectedType = 'cash';
+  String _selectedCurrency = 'RWF';
+  bool _isLoading = false;
+
+  final List<Map<String, dynamic>> _walletTypes = [
+    {'value': 'cash', 'label': 'Cash', 'icon': Icons.account_balance_wallet},
+    {'value': 'bank', 'label': 'Bank', 'icon': Icons.account_balance},
+    {'value': 'momo', 'label': 'Mobile Money', 'icon': Icons.phone_android},
+  ];
+
+  final List<String> _currencies = ['RWF', 'USD', 'EUR'];
+
+  final Map<String, List<String>> _providers = {
+    'bank': ['Bank of Kigali', 'Equity Bank', 'I&M Bank', 'Access Bank', 'Other'],
+    'momo': ['MTN', 'Airtel', 'Other'],
+  };
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController.text = widget.wallet.name;
+    _providerController.text = widget.wallet.provider ?? '';
+    _accountNumberController.text = widget.wallet.accountNumber ?? '';
+    _balanceController.text = widget.wallet.balance.toStringAsFixed(0);
+    _selectedType = widget.wallet.type;
+    _selectedCurrency = widget.wallet.currency;
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _providerController.dispose();
+    _accountNumberController.dispose();
+    _balanceController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _saveWallet() async {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+
+    setState(() => _isLoading = true);
+
+    try {
+      final updatedWallet = widget.wallet.copyWith(
+        name: _nameController.text.trim(),
+        type: _selectedType,
+        provider: _providerController.text.trim().isEmpty 
+            ? null 
+            : _providerController.text.trim(),
+        accountNumber: _accountNumberController.text.trim().isEmpty 
+            ? null 
+            : _accountNumberController.text.trim(),
+        balance: double.tryParse(_balanceController.text) ?? widget.wallet.balance,
+        currency: _selectedCurrency,
+        updatedAt: DateTime.now(),
+      );
+
+      await _walletRepository.updateWallet(updatedWallet);
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('${updatedWallet.name} updated successfully'),
+            backgroundColor: AppColors.success,
+          ),
+        );
+        Navigator.pop(context, true);
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Error updating wallet: $e'),
+            backgroundColor: AppColors.error,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Edit Wallet', style: theme.appBarTheme.titleTextStyle),
+        elevation: 0,
+        backgroundColor: Colors.transparent,
+      ),
+      body: Form(
+        key: _formKey,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Header info
+              Container(
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: AppColors.primary100,
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(color: AppColors.primary200),
+                ),
+                child: Row(
+                  children: [
+                    Container(
+                      width: 48,
+                      height: 48,
+                      decoration: BoxDecoration(
+                        color: AppColors.primary,
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                      child: Icon(
+                        _getWalletIcon(_selectedType),
+                        color: Colors.white,
+                        size: 24,
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Editing Wallet',
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: AppColors.primary700,
+                            ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            widget.wallet.name,
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.w600,
+                              color: AppColors.primary700,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 24),
+
+              // Wallet Name
+              Text(
+                'Wallet Name',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 8),
+              TextFormField(
+                controller: _nameController,
+                decoration: InputDecoration(
+                  hintText: 'e.g., My Cash Wallet',
+                  prefixIcon: const Icon(Icons.edit),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Please enter a wallet name';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 20),
+
+              // Wallet Type
+              Text(
+                'Wallet Type',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Row(
+                children: _walletTypes.map((type) {
+                  final isSelected = _selectedType == type['value'];
+                  return Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.only(right: 8),
+                      child: InkWell(
+                        onTap: () {
+                          setState(() {
+                            _selectedType = type['value'] as String;
+                            // Clear provider when type changes
+                            _providerController.clear();
+                          });
+                        },
+                        borderRadius: BorderRadius.circular(12),
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(vertical: 16),
+                          decoration: BoxDecoration(
+                            color: isSelected 
+                                ? AppColors.primary 
+                                : Colors.white,
+                            borderRadius: BorderRadius.circular(12),
+                            border: Border.all(
+                              color: isSelected 
+                                  ? AppColors.primary 
+                                  : AppColors.grayPrimary,
+                              width: isSelected ? 2 : 1,
+                            ),
+                          ),
+                          child: Column(
+                            children: [
+                              Icon(
+                                type['icon'] as IconData,
+                                color: isSelected 
+                                    ? Colors.white 
+                                    : AppColors.textSecondary,
+                                size: 24,
+                              ),
+                              const SizedBox(height: 4),
+                              Text(
+                                type['label'] as String,
+                                style: TextStyle(
+                                  color: isSelected 
+                                      ? Colors.white 
+                                      : AppColors.textSecondary,
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  );
+                }).toList(),
+              ),
+              const SizedBox(height: 20),
+
+              // Provider (conditional)
+              if (_selectedType != 'cash') ...[
+                Text(
+                  'Provider',
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                DropdownButtonFormField<String>(
+                  value: _providers[_selectedType]?.contains(_providerController.text) ?? false
+                      ? _providerController.text
+                      : null,
+                  decoration: InputDecoration(
+                    hintText: 'Select provider',
+                    prefixIcon: const Icon(Icons.business),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  items: (_providers[_selectedType] ?? []).map((provider) {
+                    return DropdownMenuItem(
+                      value: provider,
+                      child: Text(provider),
+                    );
+                  }).toList(),
+                  onChanged: (value) {
+                    if (value == 'Other') {
+                      _providerController.clear();
+                    } else if (value != null) {
+                      _providerController.text = value;
+                    }
+                  },
+                ),
+                if (_providerController.text.isEmpty || 
+                    _providerController.text == 'Other' ||
+                    !(_providers[_selectedType]?.contains(_providerController.text) ?? false)) ...[
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: _providerController,
+                    decoration: InputDecoration(
+                      hintText: 'Enter provider name',
+                      prefixIcon: const Icon(Icons.edit),
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                    ),
+                  ),
+                ],
+                const SizedBox(height: 20),
+
+                // Account Number (conditional)
+                Text(
+                  _selectedType == 'bank' ? 'Account Number' : 'Phone Number',
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                TextFormField(
+                  controller: _accountNumberController,
+                  decoration: InputDecoration(
+                    hintText: _selectedType == 'bank' 
+                        ? 'e.g., 4001234567890' 
+                        : 'e.g., 0781234567',
+                    prefixIcon: Icon(
+                      _selectedType == 'bank' 
+                          ? Icons.account_balance 
+                          : Icons.phone,
+                    ),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  keyboardType: TextInputType.number,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                ),
+                const SizedBox(height: 20),
+              ],
+
+              // Balance
+              Text(
+                'Current Balance',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 8),
+              TextFormField(
+                controller: _balanceController,
+                decoration: InputDecoration(
+                  hintText: '0',
+                  prefixIcon: const Icon(Icons.attach_money),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                keyboardType: TextInputType.number,
+                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Please enter the balance';
+                  }
+                  if (double.tryParse(value) == null) {
+                    return 'Please enter a valid number';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 20),
+
+              // Currency
+              Text(
+                'Currency',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 8),
+              DropdownButtonFormField<String>(
+                value: _selectedCurrency,
+                decoration: InputDecoration(
+                  prefixIcon: const Icon(Icons.currency_exchange),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                items: _currencies.map((currency) {
+                  return DropdownMenuItem(
+                    value: currency,
+                    child: Text(currency),
+                  );
+                }).toList(),
+                onChanged: (value) {
+                  if (value != null) {
+                    setState(() => _selectedCurrency = value);
+                  }
+                },
+              ),
+              const SizedBox(height: 32),
+
+              // Save Button
+              SizedBox(
+                width: double.infinity,
+                height: 56,
+                child: ElevatedButton(
+                  onPressed: _isLoading ? null : _saveWallet,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.primary,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: _isLoading
+                      ? const SizedBox(
+                          width: 24,
+                          height: 24,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                          ),
+                        )
+                      : const Text(
+                          'Save Changes',
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                ),
+              ),
+              const SizedBox(height: 16),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  IconData _getWalletIcon(String type) {
+    switch (type.toLowerCase()) {
+      case 'bank':
+        return Icons.account_balance;
+      case 'momo':
+        return Icons.phone_android;
+      case 'cash':
+        return Icons.account_balance_wallet;
+      default:
+        return Icons.account_balance_wallet;
+    }
+  }
+}

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -128,9 +128,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         icon: Icons.account_balance_wallet,
         title: 'Wallets',
         subtitle: 'Manage your wallets',
-        onTap: () {
-          // TODO: Navigate to wallets management
-        },
+        onTap: () => Navigator.pushNamed(context, AppRoutes.walletSettings),
       ),
       // _SettingsMenuItem(
       //   icon: Icons.notifications,

--- a/lib/features/settings/screens/wallet_settings_screen.dart
+++ b/lib/features/settings/screens/wallet_settings_screen.dart
@@ -1,0 +1,630 @@
+import 'package:flutter/material.dart';
+import '../../../core/constants/app_colors.dart';
+import '../../../core/routes/app_routes.dart';
+import '../../../data/models/wallet_model.dart';
+import '../../../data/repositories/wallet_repository.dart';
+
+class WalletSettingsScreen extends StatefulWidget {
+  const WalletSettingsScreen({super.key});
+
+  @override
+  State<WalletSettingsScreen> createState() => _WalletSettingsScreenState();
+}
+
+class _WalletSettingsScreenState extends State<WalletSettingsScreen> {
+  final WalletRepository _walletRepository = WalletRepository();
+  List<Wallet> _wallets = [];
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadWallets();
+  }
+
+  Future<void> _loadWallets() async {
+    setState(() => _isLoading = true);
+    try {
+      final wallets = _walletRepository.getAllWallets();
+      setState(() {
+        _wallets = wallets;
+        _isLoading = false;
+      });
+    } catch (e) {
+      setState(() => _isLoading = false);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Error loading wallets: $e')),
+        );
+      }
+    }
+  }
+
+  Future<void> _toggleWalletStatus(Wallet wallet) async {
+    try {
+      final updatedWallet = wallet.copyWith(
+        isActive: !wallet.isActive,
+        updatedAt: DateTime.now(),
+      );
+      await _walletRepository.updateWallet(updatedWallet);
+      await _loadWallets();
+      
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              updatedWallet.isActive 
+                ? '${wallet.name} activated' 
+                : '${wallet.name} deactivated',
+            ),
+            backgroundColor: AppColors.success,
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Error updating wallet: $e')),
+        );
+      }
+    }
+  }
+
+  Future<void> _deleteWallet(Wallet wallet) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Wallet'),
+        content: Text(
+          'Are you sure you want to delete "${wallet.name}"? This action cannot be undone.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            style: TextButton.styleFrom(
+              foregroundColor: AppColors.error,
+            ),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true) {
+      try {
+        await _walletRepository.deleteWallet(wallet.id);
+        await _loadWallets();
+        
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('${wallet.name} deleted'),
+              backgroundColor: AppColors.success,
+            ),
+          );
+        }
+      } catch (e) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Error deleting wallet: $e')),
+          );
+        }
+      }
+    }
+  }
+
+  Future<void> _editWallet(Wallet wallet) async {
+    final result = await Navigator.pushNamed(
+      context,
+      AppRoutes.editWallet,
+      arguments: wallet,
+    );
+    
+    if (result == true) {
+      await _loadWallets();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Wallet Settings', style: theme.appBarTheme.titleTextStyle),
+        elevation: 0,
+        backgroundColor: Colors.transparent,
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : _wallets.isEmpty
+              ? _buildEmptyState()
+              : _buildWalletList(),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () async {
+          final result = await Navigator.pushNamed(context, AppRoutes.createWallet);
+          if (result == true) {
+            await _loadWallets();
+          }
+        },
+        icon: const Icon(Icons.add),
+        label: const Text('Add Wallet'),
+        backgroundColor: AppColors.primary,
+      ),
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              width: 120,
+              height: 120,
+              decoration: BoxDecoration(
+                color: AppColors.primary100,
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                Icons.account_balance_wallet_outlined,
+                size: 60,
+                color: AppColors.primary,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'No Wallets Yet',
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Create your first wallet to start managing your finances',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: AppColors.textSecondary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildWalletList() {
+    // Group wallets by active status
+    final activeWallets = _wallets.where((w) => w.isActive).toList();
+    final inactiveWallets = _wallets.where((w) => !w.isActive).toList();
+
+    return RefreshIndicator(
+      onRefresh: _loadWallets,
+      child: SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Summary card
+            _buildSummaryCard(),
+            const SizedBox(height: 24),
+            
+            // Active wallets
+            if (activeWallets.isNotEmpty) ...[
+              Text(
+                'Active Wallets',
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 12),
+              ...activeWallets.map((wallet) => _buildWalletCard(wallet)),
+              const SizedBox(height: 24),
+            ],
+            
+            // Inactive wallets
+            if (inactiveWallets.isNotEmpty) ...[
+              Text(
+                'Inactive Wallets',
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.textSecondary,
+                ),
+              ),
+              const SizedBox(height: 12),
+              ...inactiveWallets.map((wallet) => _buildWalletCard(wallet)),
+            ],
+            
+            const SizedBox(height: 80), // Space for FAB
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSummaryCard() {
+    final totalBalance = _walletRepository.getTotalBalance();
+    final activeCount = _wallets.where((w) => w.isActive).length;
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [AppColors.primary, AppColors.primary.withOpacity(0.8)],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.primary.withOpacity(0.3),
+            blurRadius: 12,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: Colors.white.withOpacity(0.2),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: const Icon(
+                  Icons.account_balance_wallet,
+                  color: Colors.white,
+                  size: 20,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Total Balance',
+                      style: const TextStyle(
+                        color: Colors.white70,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      'RWF ${totalBalance.toStringAsFixed(0)}',
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 24,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Colors.white.withOpacity(0.15),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Row(
+              children: [
+                _buildSummaryItem(
+                  'Total',
+                  _wallets.length.toString(),
+                  Icons.wallet,
+                ),
+                const SizedBox(width: 24),
+                _buildSummaryItem(
+                  'Active',
+                  activeCount.toString(),
+                  Icons.check_circle,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSummaryItem(String label, String value, IconData icon) {
+    return Row(
+      children: [
+        Icon(
+          icon,
+          color: Colors.white70,
+          size: 16,
+        ),
+        const SizedBox(width: 8),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              label,
+              style: const TextStyle(
+                color: Colors.white70,
+                fontSize: 11,
+              ),
+            ),
+            Text(
+              value,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildWalletCard(Wallet wallet) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      decoration: BoxDecoration(
+        color: wallet.isActive ? Colors.white : Colors.grey.shade50,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: wallet.isActive ? AppColors.grayPrimary : Colors.grey.shade300,
+        ),
+        boxShadow: wallet.isActive
+            ? [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.04),
+                  blurRadius: 8,
+                  offset: const Offset(0, 2),
+                ),
+              ]
+            : null,
+      ),
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              children: [
+                // Icon
+                Container(
+                  width: 48,
+                  height: 48,
+                  decoration: BoxDecoration(
+                    color: wallet.isActive 
+                        ? AppColors.primary100 
+                        : Colors.grey.shade200,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Icon(
+                    _getWalletIcon(wallet.type),
+                    color: wallet.isActive 
+                        ? AppColors.primary 
+                        : Colors.grey.shade500,
+                    size: 24,
+                  ),
+                ),
+                const SizedBox(width: 16),
+                
+                // Details
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              wallet.name,
+                              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                                fontWeight: FontWeight.w600,
+                                color: wallet.isActive 
+                                    ? AppColors.textPrimary 
+                                    : AppColors.textSecondary,
+                              ),
+                            ),
+                          ),
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 8,
+                              vertical: 4,
+                            ),
+                            decoration: BoxDecoration(
+                              color: wallet.isActive 
+                                  ? AppColors.success.withOpacity(0.1)
+                                  : Colors.grey.shade300,
+                              borderRadius: BorderRadius.circular(6),
+                            ),
+                            child: Text(
+                              wallet.isActive ? 'Active' : 'Inactive',
+                              style: TextStyle(
+                                color: wallet.isActive 
+                                    ? AppColors.success 
+                                    : Colors.grey.shade600,
+                                fontSize: 11,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 4),
+                      if (wallet.provider != null)
+                        Text(
+                          wallet.provider!,
+                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: AppColors.textSecondary,
+                          ),
+                        ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'RWF ${wallet.balance.toStringAsFixed(0)}',
+                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w700,
+                          color: wallet.isActive 
+                              ? AppColors.primary 
+                              : AppColors.textSecondary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          
+          // Actions
+          Container(
+            decoration: BoxDecoration(
+              color: wallet.isActive 
+                  ? AppColors.primary.withOpacity(0.05)
+                  : Colors.grey.shade100,
+              borderRadius: const BorderRadius.only(
+                bottomLeft: Radius.circular(12),
+                bottomRight: Radius.circular(12),
+              ),
+            ),
+            child: Row(
+              children: [
+                // Edit
+                Expanded(
+                  child: InkWell(
+                    onTap: () => _editWallet(wallet),
+                    borderRadius: const BorderRadius.only(
+                      bottomLeft: Radius.circular(12),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(
+                            Icons.edit,
+                            size: 16,
+                            color: AppColors.primary,
+                          ),
+                          const SizedBox(width: 6),
+                          Text(
+                            'Edit',
+                            style: TextStyle(
+                              color: AppColors.primary,
+                              fontSize: 13,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                
+                Container(
+                  width: 1,
+                  height: 24,
+                  color: AppColors.grayPrimary,
+                ),
+                
+                // Toggle Active
+                Expanded(
+                  child: InkWell(
+                    onTap: () => _toggleWalletStatus(wallet),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(
+                            wallet.isActive 
+                                ? Icons.visibility_off 
+                                : Icons.visibility,
+                            size: 16,
+                            color: AppColors.textSecondary,
+                          ),
+                          const SizedBox(width: 6),
+                          Text(
+                            wallet.isActive ? 'Deactivate' : 'Activate',
+                            style: TextStyle(
+                              color: AppColors.textSecondary,
+                              fontSize: 13,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                
+                Container(
+                  width: 1,
+                  height: 24,
+                  color: AppColors.grayPrimary,
+                ),
+                
+                // Delete
+                Expanded(
+                  child: InkWell(
+                    onTap: () => _deleteWallet(wallet),
+                    borderRadius: const BorderRadius.only(
+                      bottomRight: Radius.circular(12),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(
+                            Icons.delete_outline,
+                            size: 16,
+                            color: AppColors.error,
+                          ),
+                          const SizedBox(width: 6),
+                          Text(
+                            'Delete',
+                            style: TextStyle(
+                              color: AppColors.error,
+                              fontSize: 13,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  IconData _getWalletIcon(String type) {
+    switch (type.toLowerCase()) {
+      case 'bank':
+        return Icons.account_balance;
+      case 'momo':
+        return Icons.phone_android;
+      case 'cash':
+        return Icons.account_balance_wallet;
+      default:
+        return Icons.account_balance_wallet;
+    }
+  }
+}


### PR DESCRIPTION
Introduces wallet management to settings with new WalletSettingsScreen and EditWalletScreen, allowing users to view, edit, activate/deactivate, and delete wallets. Updates app routes to support wallet settings and editing, and connects the settings menu to the new wallet management screen. Improves unlock screen logic to prevent multiple unlock dialogs.