### PR TITLE
Add currency selection to add transaction screen

### DIFF
--- a/lib/features/transaction/screens/add_transaction_screen.dart
+++ b/lib/features/transaction/screens/add_transaction_screen.dart
@@ -36,7 +36,11 @@ class _AddTransactionScreenState extends State<AddTransactionScreen> {
       viewModel.addListener(() {
         // Update amount controller if amount changed
         if (viewModel.amount > 0 && _amountController.text != viewModel.amount.toString()) {
-          _amountController.text = viewModel.amount.toString();
+          // Format amount to avoid unnecessary decimals
+          final amountStr = viewModel.amount % 1 == 0 
+              ? viewModel.amount.toInt().toString() 
+              : viewModel.amount.toString();
+          _amountController.text = amountStr;
         }
         // Update description controller if description changed
         if (viewModel.description.isNotEmpty && _transactionNameController.text != viewModel.description) {
@@ -640,12 +644,37 @@ class _AddTransactionScreenState extends State<AddTransactionScreen> {
               ),
               const SizedBox(width: 12),
               
+              // Currency selector
+              Container(
+                height: 56,
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                decoration: BoxDecoration(
+                  border: Border.all(color: Colors.grey.shade300),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: DropdownButtonHideUnderline(
+                  child: DropdownButton<String>(
+                    value: viewModel.currency,
+                    items: const [
+                      DropdownMenuItem(value: 'RWF', child: Text('RWF')),
+                      DropdownMenuItem(value: 'USD', child: Text('USD')),
+                    ],
+                    onChanged: (value) {
+                      if (value != null) {
+                        viewModel.setCurrency(value);
+                      }
+                    },
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              
               // Amount input
               Expanded(
                 child: TextField(
                   controller: _amountController,
                   decoration: InputDecoration(
-                    hintText: 'Enter new amount',
+                    hintText: 'Enter amount',
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(12),
                       borderSide: const BorderSide(color: AppColors.primary, width: 2),
@@ -659,7 +688,7 @@ class _AddTransactionScreenState extends State<AddTransactionScreen> {
                       borderSide: const BorderSide(color: AppColors.primary, width: 2),
                     ),
                   ),
-                  keyboardType: TextInputType.number,
+                  keyboardType: const TextInputType.numberWithOptions(decimal: true),
                   onChanged: (value) {
                     final amount = double.tryParse(value.replaceAll(',', '')) ?? 0;
                     viewModel.setAmount(amount);

--- a/lib/features/transaction/viewmodels/add_transaction_viewmodel.dart
+++ b/lib/features/transaction/viewmodels/add_transaction_viewmodel.dart
@@ -23,6 +23,7 @@ class AddTransactionViewModel extends ChangeNotifier {
   String _description = '';
   DateTime _date = DateTime.now();
   Wallet? _selectedWallet;
+  String _currency = 'RWF'; // Default to RWF
   String? _note;
   String? _receiptPath;
   Transaction? _editingTransaction;
@@ -40,6 +41,7 @@ class AddTransactionViewModel extends ChangeNotifier {
   String get description => _description;
   DateTime get date => _date;
   Wallet? get selectedWallet => _selectedWallet;
+  String get currency => _currency;
   String? get note => _note;
   String? get receiptPath => _receiptPath;
   List<Wallet> get wallets => _wallets;
@@ -126,6 +128,12 @@ class AddTransactionViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Set currency
+  void setCurrency(String currency) {
+    _currency = currency;
+    notifyListeners();
+  }
+
   /// Set note
   void setNote(String? value) {
     _note = value;
@@ -160,7 +168,7 @@ class AddTransactionViewModel extends ChangeNotifier {
           type: _type == TransactionType.income ? 'credit' : 'debit',
           category: _selectedCategory!.name,
           amount: _amount,
-          currency: _selectedWallet!.currency,
+          currency: _currency,
           description: _description,
           walletId: _selectedWallet!.id,
           rawMessage: _note ?? '',
@@ -185,8 +193,8 @@ class AddTransactionViewModel extends ChangeNotifier {
           type: _type == TransactionType.income ? 'credit' : 'debit',
           category: _selectedCategory!.name,
           amount: _amount,
-          currency: _selectedWallet!.currency,
-          amountRWF: _selectedWallet!.currency == 'RWF'
+          currency: _currency,
+          amountRWF: _currency == 'RWF'
               ? _amount
               : _amount * 1440, // Convert USD to RWF
           description: _description,


### PR DESCRIPTION
Introduces a currency dropdown selector (RWF, USD) to the add transaction screen and updates the viewmodel to store and use the selected currency. Amount formatting is improved to avoid unnecessary decimals, and the amount input now allows decimal values. Transaction creation now uses the selected currency instead of the wallet's default.